### PR TITLE
Add in md5 check for uploads and retry

### DIFF
--- a/CIHM-Meta/bin/ocrload
+++ b/CIHM-Meta/bin/ocrload
@@ -181,36 +181,32 @@ sub matching_aip_dir {
 }
 =cut
 
-my $donedirs = <<DONEDIRS;
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15869
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15870
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15867
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15868
+my $ocrdirs = <<OCRDIRS;
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 475 - heritage - done - verified/lac_reel_t15795
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 475 - heritage - done - verified/lac_reel_t15796
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 475 - heritage - done - verified/lac_reel_t15797
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 475 - heritage - done - verified/lac_reel_t15795
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 477 - Heritage - completed - verified/lac_reel_t15596
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 480 - Heritage - completed/lac_reel_t15663
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 480 - Heritage - completed/lac_reel_t15807
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 480 - Heritage - completed/lac_reel_t15808
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 480 - Heritage - completed/lac_reel_t15809
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 480 - Heritage - completed/lac_reel_t15807
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 480 - Heritage - completed/lac_reel_t15663
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 482 - Heritage - completed/lac_reel_t15815
-
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 490 - Heritage - completed - verified/lac_reel_t15838
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 490 - Heritage - completed - verified/lac_reel_t15839
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 490 - Heritage - completed - verified/lac_reel_t15837
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 486 - Heritage/lac_reel_t15825
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 486 - Heritage/lac_reel_t15826
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 486 - Heritage/lac_reel_t15827
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 486 - Heritage/lac_reel_t15825
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 487 - Heritage/lac_reel_t15828
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 487 - Heritage/lac_reel_t15829
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 487 - Heritage/lac_reel_t15830
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 487 - Heritage/lac_reel_t15828
-DONEDIRS
-
-my $ocrdirs = <<OCRDIRS;
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 488 - Heritage - completed - verified/lac_reel_t15831
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 488 - Heritage - completed - verified/lac_reel_t15832
 /home/tdr/ocr-todo/_Russell_Ingest/Batch 488 - Heritage - completed - verified/lac_reel_t15833
-/home/tdr/ocr-todo/_Russell_Ingest/Batch 488 - Heritage - completed - verified/lac_reel_t15831
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 490 - Heritage - completed - verified/lac_reel_t15837
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 490 - Heritage - completed - verified/lac_reel_t15838
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 490 - Heritage - completed - verified/lac_reel_t15839
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15867
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15868
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15869
+/home/tdr/ocr-todo/_Russell_Ingest/Batch 500 - Heritage - completed/lac_reel_t15870
 OCRDIRS
 
 # Forward or reverse....

--- a/CIHM-Meta/bin/ocrtask
+++ b/CIHM-Meta/bin/ocrtask
@@ -39,6 +39,10 @@ my $swift_access_files;
 $swift_access_files = $ENV{SWIFT_access_files}
   if ( exists $ENV{SWIFT_access_files} );
 
+my $swift_retries = 5;
+$swift_retries = $ENV{SWIFT_retries}
+  if ( exists $ENV{SWIFT_retries} );
+
 my $couchdb_ocrtask;
 $couchdb_ocrtask = $ENV{COUCHDB_OCRTASK} if ( exists $ENV{COUCHDB_OCRTASK} );
 
@@ -60,6 +64,7 @@ GetOptions(
     'swift_account:s'         => \$swift_account,
     'swift_access_metadata:s' => \$swift_access_metadata,
     'swift_access_files:s'    => \$swift_access_files,
+    'swift_retries:i'         => \$swift_retries,
 );
 
 # Only allow one instance to run at a time..
@@ -67,6 +72,9 @@ sysopen( FH, $lockfile, O_WRONLY | O_CREAT )
   or die "can't open lockfile=$lockfile: $!\n";
 flock( FH, LOCK_EX | LOCK_NB )
   or exit 0;
+
+$swift_retries = int($swift_retries);
+die "swift_retries must be a positive integer\n" if ( $swift_retries < 1 );
 
 die "couchdb_ocrtask is mandatory (environment or parameter)\n"
   if ( !$couchdb_ocrtask );
@@ -90,6 +98,7 @@ try {
             swift_account         => $swift_account,
             swift_access_metadata => $swift_access_metadata,
             swift_access_files    => $swift_access_files,
+            swift_retries         => $swift_retries,
             couchdb_access        => $couchdb_access,
             couchdb_canvas        => $couchdb_canvas,
             couchdb_ocrtask       => $couchdb_ocrtask,

--- a/CIHM-Meta/bin/smelter
+++ b/CIHM-Meta/bin/smelter
@@ -29,7 +29,8 @@ my $swift_preservation_server;
 $swift_preservation_server = $ENV{SWIFT_preservation_server}
   if ( exists $ENV{SWIFT_preservation_server} );
 
-my $swift_preservation_server_options = '{ "furl_options": { "timeout": 3600 } }';
+my $swift_preservation_server_options =
+  '{ "furl_options": { "timeout": 3600 } }';
 $swift_preservation_server_options = $ENV{SWIFT_preservation_server_options}
   if ( exists $ENV{SWIFT_preservation_server_options} );
 
@@ -79,6 +80,10 @@ my $swift_access_files;
 $swift_access_files = $ENV{SWIFT_access_files}
   if ( exists $ENV{SWIFT_access_files} );
 
+my $swift_retries = 5;
+$swift_retries = $ENV{SWIFT_retries}
+  if ( exists $ENV{SWIFT_retries} );
+
 ########
 
 my $noid_server;
@@ -125,10 +130,14 @@ GetOptions(
     'swift_preservation_password:s' => \$swift_preservation_password,
     'swift_preservation_account:s'  => \$swift_preservation_account,
     'swift_preservation_files:s'    => \$swift_preservation_files,
+    'swift_retries:i'               => \$swift_retries,
     'noid_server:s'                 => \$noid_server,
     'iiif_image_server:s'           => \$iiif_image_server,
     'iiif_image_password:s'         => \$iiif_image_password,
 );
+
+$swift_retries = int($swift_retries);
+die "swift_retries must be a positive integer\n" if ( $swift_retries < 1 );
 
 # Only allow one instance to run at a time..
 sysopen( FH, $lockfile, O_WRONLY | O_CREAT )
@@ -176,6 +185,7 @@ CIHM::Meta::Smelter->new(
         swift_preservation_password       => $swift_preservation_password,
         swift_preservation_account        => $swift_preservation_account,
         swift_preservation_files          => $swift_preservation_files,
+        swift_retries                     => $swift_retries,
         noid_server                       => $noid_server,
         iiif_image_server                 => $iiif_image_server,
         iiif_image_password               => $iiif_image_password,

--- a/CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm
+++ b/CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm
@@ -654,8 +654,7 @@ sub ocrCanvases {
                     open( my $fh, '<:raw', $thispdf )
                       or die "Could not open file '$thispdf' $!\n";
 
-                    my $md5 = Digest::MD5->new;
-                    $md5->addfile($fh);
+                    my $md5 = Digest::MD5->new->addfile($fh)->hexdigest;
 
                     seek $fh, 0, SEEK_SET;
 
@@ -667,12 +666,15 @@ sub ocrCanvases {
                               . $putresp->message
                               . "\n" );
                     }
+                    elsif ( $putresp->etag ne $md5 ) {
+                        die "object_put $object didn't return matching etag\n";
+                    }
                     close $fh;
 
                     $canvas->{'ocrPdf'} = {
                         'extension' => 'pdf',
                         'size'      => $bytes,
-                        'md5'       => $md5->hexdigest
+                        'md5'       => $md5
                     };
                     $modified = JSON::true;
                 }

--- a/CIHM-Meta/lib/CIHM/Meta/Ocrtask.pm
+++ b/CIHM-Meta/lib/CIHM/Meta/Ocrtask.pm
@@ -193,7 +193,7 @@ sub ocrtask {
     # Capture warnings
     local $SIG{__WARN__} = sub { &collect_warnings };
 
-    $self->log->info( "Ocrtask maxprocs=" . $self->maxprocs );
+    $self->log->info( "Ocrtask: maxprocs=" . $self->maxprocs );
 
     $self->ocrtaskdb->type("application/json");
     my $url =

--- a/CIHM-Meta/lib/CIHM/Meta/Ocrtask.pm
+++ b/CIHM-Meta/lib/CIHM/Meta/Ocrtask.pm
@@ -113,6 +113,11 @@ sub access_files {
     return $self->args->{swift_access_files};
 }
 
+sub swift_retries {
+    my $self = shift;
+    return $self->args->{swift_retries};
+}
+
 sub swift {
     my $self = shift;
     return $self->{swift};
@@ -502,24 +507,41 @@ sub updateFile {
           . $res->message . "\n";
     }
 
-    # Send file.
-    my $putresp =
-      $self->swift->object_put( $container, $object, $fh,
-        { 'File-Modified' => $filedate } );
-    if ( $putresp->code != 201 ) {
-        die(    "object_put of $object into $container returned "
-              . $putresp->code . " - "
-              . $putresp->message
-              . "\n" );
-    }
-    close $fh;
+    my $tries = $self->swift_retries;
 
-    # Extra check that everything was OK.
-    warn "Etag mismatch during object_put of $object into $container: $md5digest != "
-      . $putresp->etag
-      . " during "
-      . $putresp->transaction_id . "\n"
-      if $md5digest ne $putresp->etag;
+    do {
+
+        # Send file.
+        seek( $fh, 0, 0 );
+        my $putresp =
+          $self->swift->object_put( $container, $object, $fh,
+            { 'File-Modified' => $filedate } );
+        if ( $putresp->code != 201 ) {
+            die(    "object_put of $object into $container returned "
+                  . $putresp->code . " - "
+                  . $putresp->message
+                  . "\n" );
+        }
+
+        if ( $md5digest eq $putresp->etag ) {
+            $tries = 0;
+        }
+        else {
+            # Extra check that everything was OK.
+            warn
+"Etag mismatch during object_put of $object into $container: $filename=$md5digest $object="
+              . $putresp->etag
+              . " during "
+              . $putresp->transaction_id
+              . " retries=$tries\n";
+
+            if ( !$tries ) {
+                die "No more retries\n";
+            }
+        }
+
+    } until ( !$tries );
+    close $fh;
 
     return { size => $size, md5digest => $md5digest };
 }


### PR DESCRIPTION
#43

All tools need to properly check the MD5 of the file that was sent, as it can sometimes store a 0  length file.


```
russell@russell-XPS-13-7390:~/git/cihm-metadatabus$ find CIHM-Meta/ -type f -exec grep object_put {} /dev/null \;
CIHM-Meta/lib/CIHM/Meta/Smelter/Process.pm:        $r = $self->swiftaccess->object_put( $self->swift_access_metadata,
CIHM-Meta/lib/CIHM/Meta/Smelter/Process.pm:            die "object_put didn't return matching etag\n";
CIHM-Meta/lib/CIHM/Meta/Smelter/Process.pm:                  $self->swiftaccess->object_put( $self->swift_access_files,
CIHM-Meta/lib/CIHM/Meta/Smelter/Process.pm:                    warn "MD5 mismatch object_put("
CIHM-Meta/lib/CIHM/Meta/Dmdtask.pm:          $self->swift->object_put( $self->access_metadata, $object,
CIHM-Meta/lib/CIHM/Meta/Dmdtask.pm:            warn "object_put($object) didn't return matching etag\n";
CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm:                              $self->swift->object_put( $self->access_metadata,
CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm:"object_put $object didn't return matching etag\n";
CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm:                          $self->swift->object_put( $self->access_metadata,
CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm:"object_put $object didn't return matching etag\n";
CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm:                    my $putresp = $self->swift->object_put( $self->access_files,
CIHM-Meta/lib/CIHM/Meta/ImportOCR/Process.pm:                        die(    "object_put of $object returned "
CIHM-Meta/lib/CIHM/Meta/Ocrtask.pm:      $self->swift->object_put( $container, $object, $fh,
CIHM-Meta/lib/CIHM/Meta/Ocrtask.pm:        die(    "object_put of $object into $container returned "
CIHM-Meta/lib/CIHM/Meta/Ocrtask.pm:    warn "Etag mismatch during object_put of $object into $container: $md5digest != "
russell@russell-XPS-13-7390:~/git/cihm-metadatabus$ 
```
